### PR TITLE
update to use fixed aiocometd

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple, async-based, reverse-engineered API for tastyworks. This will allow yo
 
 Please note that this is in the very early stages of development so any and all contributions are welcome. Please submit an issue and/or a pull request.
 
-This is a fork with modified and added features. You can find the original GitHub repo at: https://github.com/boyan-soubachov/tastyworks_api
+This is a fork with modified and added features. You can find the original (unmaintained) GitHub repo at: https://github.com/boyan-soubachov/tastyworks_api
 
 ## Installation
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.7.4
-aiocometd==0.4.5
+git+https://github.com/Graeme22/aiocometd@0.4.5.3#egg=aiocometd
 requests==2.26.0
 pytest==6.2.4
 pytest-cov==2.12.0

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,12 @@ setup(
     long_description_content_type='text/markdown',
     author='Graeme Holliday',
     author_email='graeme.holliday@pm.me',
-    url='https://github.com/Graeme22/tastyworks-api',
+    url='https://github.com/tastyware/tastyworks-api',
     license='Apache',
     install_requires=[
         'aiohttp<4',
         'requests<3',
-        'aiocometd',
+        'aiocometd @ git+https://github.com/Graeme22/aiocometd@0.4.5.3#egg=aiocometd',
         'dataclasses'
     ],
     packages=find_packages(exclude=['ez_setup', 'tests*']),

--- a/tastyworks/utils.py
+++ b/tastyworks/utils.py
@@ -1,7 +1,7 @@
 import calendar
 from datetime import date, timedelta
 
-VERSION = '4.2.2'
+VERSION = '4.3.0'
 
 
 def get_third_friday(d):


### PR DESCRIPTION
# Problem addressed

`aiocometd` doesn't handle certain errors, making it impossible to close a `DataStreamer` without throwing an unhandleable error. Updating to my fork of `aiocometd` fixes this, as the library is no longer maintained.

# Solution

Version of `aiocometd` is now a tag of my fork.

# Checklist

- PR commits have been squashed
- All tests pass
