### PR TITLE
Feature/fix python

### DIFF
--- a/docs/example.py
+++ b/docs/example.py
@@ -70,10 +70,10 @@ async def main_loop(session: TastyAPISession, streamer: DataStreamer):
         options[idx_match].greeks = gd
         print('> Symbol: {}\tPrice: {}\tDelta {}'.format(gd.symbol, gd.price, gd.delta))
 
-	quote = await streamer.stream('Quote', sub_values)
-    print(f'Received item: {quote}')
+        quote = await streamer.stream('Quote', sub_values)
+        print(f'Received item: {quote}')
 
-await streamer.close()
+        await streamer.close()
 
 
 if __name__ == '__main__':

--- a/docs/example.py
+++ b/docs/example.py
@@ -32,10 +32,10 @@ async def main_loop(session: TastyAPISession, streamer: DataStreamer):
     new_order = Order(details)
 
     opt = Option(
-        ticker='AKS',
+        ticker='SPY',
         quantity=1,
         expiry=get_third_friday(date.today()),
-        strike=D(3),
+        strike=D(400),
         option_type=OptionType.CALL,
         underlying_type=UnderlyingType.EQUITY
     )
@@ -45,7 +45,7 @@ async def main_loop(session: TastyAPISession, streamer: DataStreamer):
     print(f'Order executed successfully: {res}')
 
     # Get an options chain
-    undl = underlying.Underlying('AKS')
+    undl = underlying.Underlying('SPY')
 
     chain = await option_chain.get_option_chain(session, undl)
     print(f'Chain strikes: {chain.get_all_strikes()}')

--- a/docs/example.py
+++ b/docs/example.py
@@ -1,0 +1,94 @@
+import asyncio
+from datetime import date
+from decimal import Decimal as D
+
+from tastyworks.models import option_chain, underlying
+from tastyworks.models.greeks import Greeks
+from tastyworks.models.option import Option, OptionType
+from tastyworks.models.order import (Order, OrderDetails, OrderPriceEffect,
+                                     OrderType)
+from tastyworks.models.session import TastyAPISession
+from tastyworks.models.trading_account import TradingAccount
+from tastyworks.models.underlying import UnderlyingType
+from tastyworks.streamer import DataStreamer
+from tastyworks.tastyworks_api import tasty_session
+from tastyworks.utils import get_third_friday
+
+
+async def main_loop(session: TastyAPISession, streamer: DataStreamer):
+    accounts = await TradingAccount.get_remote_accounts(session)
+    acct = accounts[0]
+    print(f'Accounts available: {accounts}')
+
+    orders = await Order.get_remote_orders(session, acct)
+    print(f'Number of active orders: {len(orders)}')
+
+    # Execute an order
+    details = OrderDetails(
+        type=OrderType.LIMIT,
+        price=D(400),
+        price_effect=OrderPriceEffect.CREDIT)
+    new_order = Order(details)
+
+    opt = Option(
+        ticker='AKS',
+        quantity=1,
+        expiry=get_third_friday(date.today()),
+        strike=D(3),
+        option_type=OptionType.CALL,
+        underlying_type=UnderlyingType.EQUITY
+    )
+    new_order.add_leg(opt)
+
+    res = await acct.execute_order(new_order, session, dry_run=True)
+    print(f'Order executed successfully: {res}')
+
+    # Get an options chain
+    undl = underlying.Underlying('AKS')
+
+    chain = await option_chain.get_option_chain(session, undl)
+    print(f'Chain strikes: {chain.get_all_strikes()}')
+
+    # Get all expirations for the options for the above equity symbol
+    exp = chain.get_all_expirations()
+
+    # Choose the next expiration as an example & fetch the entire options chain for that expiration (all strikes)
+    next_exp = exp[0]
+    chain_next_exp = await option_chain.get_option_chain(session, undl, next_exp)
+    options = []
+    for option in chain_next_exp.options:
+        options.append(option)
+
+    # Get the greeks data for all option symbols via the streamer by subscribing
+    options_symbols = [options[x].symbol_dxf for x in range(len(options))]
+    greeks_data = await streamer.stream('Greeks', options_symbols)
+
+    for data in greeks_data:
+        gd = Greeks().from_streamer_dict(data)
+        # gd = Greeks(kwargs=data)
+        idx_match = [options[x].symbol_dxf for x in range(len(options))].index(gd.symbol)
+        options[idx_match].greeks = gd
+        print('> Symbol: {}\tPrice: {}\tDelta {}'.format(gd.symbol, gd.price, gd.delta))
+
+	quote = await streamer.stream('Quote', sub_values)
+    print(f'Received item: {quote}')
+
+await streamer.close()
+
+
+if __name__ == '__main__':
+    tasty_client = tasty_session.create_new_session('foo', 'bar')
+    streamer = DataStreamer(tasty_client)
+    loop = asyncio.get_event_loop()
+
+    try:
+        loop.run_until_complete(main_loop(tasty_client, streamer))
+    except Exception:
+        print('Exception in main loop')
+    finally:
+        # find all futures/tasks still running and wait for them to finish
+        pending_tasks = [
+            task for task in asyncio.Task.all_tasks() if not task.done()
+        ]
+        loop.run_until_complete(asyncio.gather(*pending_tasks))
+        loop.close()

--- a/docs/example.py
+++ b/docs/example.py
@@ -83,16 +83,5 @@ if __name__ == '__main__':
     password = os.environ.get('TASTY_PASSWORD')
     tasty_client = tasty_session.create_new_session(user, password)
     streamer = DataStreamer(tasty_client)
-    loop = asyncio.get_event_loop()
 
-    try:
-        loop.run_until_complete(main_loop(tasty_client, streamer))
-    except Exception:
-        print('Exception in main loop')
-    finally:
-        # find all futures/tasks still running and wait for them to finish
-        pending_tasks = [
-            task for task in asyncio.Task.all_tasks() if not task.done()
-        ]
-        loop.run_until_complete(asyncio.gather(*pending_tasks))
-        loop.close()
+    asyncio.run(main_loop(tasty_client, streamer))

--- a/docs/example.py
+++ b/docs/example.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 from datetime import date
 from decimal import Decimal as D
@@ -77,7 +78,10 @@ async def main_loop(session: TastyAPISession, streamer: DataStreamer):
 
 
 if __name__ == '__main__':
-    tasty_client = tasty_session.create_new_session('foo', 'bar')
+    # Get environment variables
+    user = os.getenv('TASTY_USER')
+    password = os.environ.get('TASTY_PASSWORD')
+    tasty_client = tasty_session.create_new_session(user, password)
     streamer = DataStreamer(tasty_client)
     loop = asyncio.get_event_loop()
 


### PR DESCRIPTION
- depends on https://github.com/tastyware/tastyworks-api/pull/6
- fixes the asyncio loop
- I don't know much about asyncio
- I changed the ticker so that the loop progresses further

I get the following output now which is much better than before:
```
Accounts available: [TradingAccount(account_number=xxxxx]
Number of active orders: 1
Order executed successfully: {'order': {'account-number': 'xxx', 'time-in-force': 'Day', 'order-type': 'Limit', 'size': 1, 'underlying-symbol': 'SPY', 'underlying-instrument-type': 'Equity', 'price': '400.0', 'price-effect': 'Credit', 'status': 'Received', 'cancellable': True, 'editable': True, 'edited': False, 'updated-at': 0, 'legs': [{'instrument-type': 'Equity Option', 'symbol': 'SPY   221216C00400000', 'quantity': 1, 'remaining-quantity': 1, 'action': 'Sell to Open', 'fills': []}]}, 'warnings': [{'code': 'tif_next_valid_sesssion', 'message': 'Your order will begin working during next valid session.'}], 'buying-power-effect': {'change-in-margin-requirement': '8294.6', 'change-in-margin-requirement-effect': 'Debit', 'change-in-buying-power': '31704.25782', 'change-in-buying-power-effect': 'Credit', 'current-buying-power': '4701.027', 'current-buying-power-effect': 'Credit', 'new-buying-power': '36405.28482', 'new-buying-power-effect': 'Credit', 'isolated-order-margin-requirement': '8294.6', 'isolated-order-margin-requirement-effect': 'Debit', 'is-spread': False, 'impact': '31704.25782', 'effect': 'Credit'}, 'fee-calculation': {'regulatory-fees': '0.04218', 'regulatory-fees-effect': 'Debit', 'clearing-fees': '0.1', 'clearing-fees-effect': 'Debit', 'commission': '1.0', 'commission-effect': 'Debit', 'proprietary-index-option-fees': '0.0', 'proprietary-index-option-fees-effect': 'None', 'total-fees': '1.14218', 'total-fees-effect': 'Debit'}}
Chain strikes: [Decimal('85.0'), Decimal('90.0'), Decimal('95.0'), Decimal('100.0'), Decimal('105.0'), Decimal('110.0'), Decimal('115.0'), Decimal('120.0'), Decimal('125.0'), Decimal('130.0'), Decimal('135.0'), Decimal('140.0'), Decimal('145.0'), Decimal('150.0'), Decimal('155.0'), Decimal('160.0'), Decimal('165.0'), Decimal('170.0'), Decimal('175.0'), Decimal('180.0'), Decimal('185.0'), Decimal('190.0'), Decimal('195.0'), Decimal('200.0'), Decimal('205.0'), Decimal('210.0'), Decimal('215.0'), Decimal('220.0'), Decimal('225.0'), Decimal('230.0'), Decimal('235.0'), Decimal('240.0'), Decimal('245.0'), Decimal('250.0'), Decimal('255.0'), Decimal('260.0'), Decimal('265.0'), Decimal('270.0'), Decimal('275.0'), Decimal('280.0'), Decimal('285.0'), Decimal('290.0'), Decimal('295.0'), Decimal('300.0'), Decimal('301.0'), Decimal('302.0'), Decimal('303.0'), Decimal('304.0'), Decimal('305.0'), Decimal('306.0'), Decimal('307.0'), Decimal('308.0'), Decimal('309.0'), Decimal('310.0'), Decimal('311.0'), Decimal('312.0'), Decimal('313.0'), Decimal('314.0'), Decimal('315.0'), Decimal('316.0'), Decimal('317.0'), Decimal('318.0'), Decimal('319.0'), Decimal('320.0'), Decimal('321.0'), Decimal('322.0'), Decimal('323.0'), Decimal('324.0'), Decimal('325.0'), Decimal('326.0'), Decimal('327.0'), Decimal('328.0'), Decimal('329.0'), Decimal('330.0'), Decimal('331.0'), Decimal('332.0'), Decimal('333.0'), Decimal('334.0'), Decimal('335.0'), Decimal('336.0'), Decimal('337.0'), Decimal('338.0'), Decimal('339.0'), Decimal('340.0'), Decimal('341.0'), Decimal('342.0'), Decimal('343.0'), Decimal('344.0'), Decimal('345.0'), Decimal('346.0'), Decimal('347.0'), Decimal('347.5'), Decimal('348.0'), Decimal('349.0'), Decimal('350.0'), Decimal('351.0'), Decimal('352.0'), Decimal('352.5'), Decimal('353.0'), Decimal('354.0'), Decimal('355.0'), Decimal('356.0'), Decimal('357.0'), Decimal('357.5'), Decimal('358.0'), Decimal('359.0'), Decimal('360.0'), Decimal('361.0'), Decimal('362.0'), Decimal('362.5'), Decimal('363.0'), Decimal('364.0'), Decimal('365.0'), Decimal('366.0'), Decimal('367.0'), Decimal('367.5'), Decimal('368.0'), Decimal('369.0'), Decimal('370.0'), Decimal('371.0'), Decimal('372.0'), Decimal('372.5'), Decimal('373.0'), Decimal('374.0'), Decimal('375.0'), Decimal('376.0'), Decimal('377.0'), Decimal('377.5'), Decimal('378.0'), Decimal('379.0'), Decimal('380.0'), Decimal('381.0'), Decimal('382.0'), Decimal('382.5'), Decimal('383.0'), Decimal('384.0'), Decimal('385.0'), Decimal('386.0'), Decimal('387.0'), Decimal('387.5'), Decimal('388.0'), Decimal('389.0'), Decimal('390.0'), Decimal('391.0'), Decimal('392.0'), Decimal('392.5'), Decimal('393.0'), Decimal('394.0'), Decimal('395.0'), Decimal('396.0'), Decimal('397.0'), Decimal('397.5'), Decimal('398.0'), Decimal('399.0'), Decimal('400.0'), Decimal('401.0'), Decimal('402.0'), Decimal('403.0'), Decimal('404.0'), Decimal('405.0'), Decimal('406.0'), Decimal('407.0'), Decimal('408.0'), Decimal('409.0'), Decimal('410.0'), Decimal('411.0'), Decimal('412.0'), Decimal('413.0'), Decimal('414.0'), Decimal('415.0'), Decimal('416.0'), Decimal('417.0'), Decimal('418.0'), Decimal('419.0'), Decimal('420.0'), Decimal('421.0'), Decimal('422.0'), Decimal('423.0'), Decimal('424.0'), Decimal('425.0'), Decimal('426.0'), Decimal('427.0'), Decimal('428.0'), Decimal('429.0'), Decimal('430.0'), Decimal('431.0'), Decimal('432.0'), Decimal('433.0'), Decimal('434.0'), Decimal('435.0'), Decimal('436.0'), Decimal('437.0'), Decimal('438.0'), Decimal('439.0'), Decimal('440.0'), Decimal('441.0'), Decimal('442.0'), Decimal('443.0'), Decimal('444.0'), Decimal('445.0'), Decimal('446.0'), Decimal('447.0'), Decimal('448.0'), Decimal('449.0'), Decimal('450.0'), Decimal('451.0'), Decimal('452.0'), Decimal('453.0'), Decimal('454.0'), Decimal('455.0'), Decimal('456.0'), Decimal('457.0'), Decimal('458.0'), Decimal('459.0'), Decimal('460.0'), Decimal('461.0'), Decimal('462.0'), Decimal('463.0'), Decimal('464.0'), Decimal('465.0'), Decimal('466.0'), Decimal('467.0'), Decimal('468.0'), Decimal('469.0'), Decimal('470.0'), Decimal('471.0'), Decimal('472.0'), Decimal('473.0'), Decimal('474.0'), Decimal('475.0'), Decimal('476.0'), Decimal('477.0'), Decimal('478.0'), Decimal('479.0'), Decimal('480.0'), Decimal('481.0'), Decimal('482.0'), Decimal('483.0'), Decimal('484.0'), Decimal('485.0'), Decimal('486.0'), Decimal('487.0'), Decimal('488.0'), Decimal('489.0'), Decimal('490.0'), Decimal('491.0'), Decimal('492.0'), Decimal('493.0'), Decimal('494.0'), Decimal('495.0'), Decimal('496.0'), Decimal('497.0'), Decimal('498.0'), Decimal('499.0'), Decimal('500.0'), Decimal('501.0'), Decimal('502.0'), Decimal('503.0'), Decimal('504.0'), Decimal('505.0'), Decimal('506.0'), Decimal('507.0'), Decimal('508.0'), Decimal('509.0'), Decimal('510.0'), Decimal('511.0'), Decimal('512.0'), Decimal('513.0'), Decimal('514.0'), Decimal('515.0'), Decimal('516.0'), Decimal('517.0'), Decimal('518.0'), Decimal('519.0'), Decimal('520.0'), Decimal('521.0'), Decimal('522.0'), Decimal('523.0'), Decimal('525.0'), Decimal('530.0'), Decimal('535.0'), Decimal('540.0'), Decimal('545.0'), Decimal('550.0'), Decimal('555.0'), Decimal('560.0'), Decimal('565.0'), Decimal('570.0'), Decimal('575.0'), Decimal('580.0'), Decimal('585.0'), Decimal('590.0'), Decimal('595.0'), Decimal('600.0'), Decimal('605.0'), Decimal('610.0'), Decimal('615.0'), Decimal('620.0'), Decimal('625.0'), Decimal('630.0'), Decimal('635.0'), Decimal('640.0'), Decimal('645.0'), Decimal('650.0'), Decimal('655.0'), Decimal('660.0'), Decimal('665.0'), Decimal('670.0'), Decimal('675.0'), Decimal('680.0'), Decimal('685.0'), Decimal('690.0'), Decimal('695.0'), Decimal('700.0'), Decimal('705.0'), Decimal('710.0'), Decimal('715.0'), Decimal('720.0')]
Traceback (most recent call last):
  File "/Users/avion/Documents/programming/trading/tasty/tastyworks/docs/example.py", line 87, in <module>
    asyncio.run(main_loop(tasty_client, streamer))
  File "/opt/homebrew/Cellar/python@3.10/3.10.8/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/opt/homebrew/Cellar/python@3.10/3.10.8/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/Users/avion/Documents/programming/trading/tasty/tastyworks/docs/example.py", line 65, in main_loop
    greeks_data = await streamer.stream('Greeks', options_symbols)
  File "/opt/homebrew/lib/python3.10/site-packages/tastyworks/streamer.py", line 107, in stream
    await self.add_data_sub(streamer_dict)
  File "/opt/homebrew/lib/python3.10/site-packages/tastyworks/streamer.py", line 32, in add_data_sub
    await self._send_msg(dxfeed.SUBSCRIPTION_CHANNEL, {'add': values})
  File "/opt/homebrew/lib/python3.10/site-packages/tastyworks/streamer.py", line 43, in _send_msg
    if not self.logged_in:
AttributeError: 'DataStreamer' object has no attribute 'logged_in'
```